### PR TITLE
Persist talent grader results for ranking integration

### DIFF
--- a/ranking.js
+++ b/ranking.js
@@ -1,5 +1,5 @@
-// 1️⃣ Speed grades (default 0 = not set)
-const speedGrades = {
+// 1️⃣ Speed grades (defaults can be overridden by saved talent grades)
+const speedGrades = Object.assign({
   "جبر و معادله":0, "دایره":0, "الکتریسیته ساکن":0, "آشنایی با مبانی ریاضیات":0,
   "قدر هدایای زمینی":0, "تابع":0, "ماتریس و کاربردها":0, "آشنایی با نظریه اعداد":0,
   "حرکت بر خط راست":0, "مولکول‌ها در خدمت تندرستی":0, "جریان الکتریکی":0, "احتمال":0,
@@ -12,7 +12,7 @@ const speedGrades = {
   "کار، انرژی و توان":0, "ردپای گازها در زندگی":0, "تابع + شمارش":0, "دما و گرما":0,
   "ردپای گازها + آب":0, "مغناطیس":0, "توابع نمایی و لگاریتمی":0,
   "در پی غذای سالم":0, "ریاضیات گسسته":0, "محاسبات برداری":0
-};
+}, JSON.parse(localStorage.getItem('speedGrades')||'{}'));
 
 // 2️⃣ Major → subject-weight & color
 const majorConfig = {

--- a/talentgrader.html
+++ b/talentgrader.html
@@ -38,6 +38,7 @@
         .criterion { display: flex; flex-direction: column; }
         .criterion label { font-size: 0.9em; margin-bottom: 5px; color: #555; }
         .static-box { padding: 8px; border: 1px solid var(--border); border-radius: 6px; text-align: center; background-color: var(--grade-bg); font-size: 1em; }
+        .grade-input { width: 100%; padding: 8px; border: 1px solid var(--border); border-radius: 6px; text-align: center; background-color: var(--grade-bg); font-size: 1em; }
         .total-grade-container { display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 15px; background-color: var(--grade-bg); border-radius: 10px; min-width: 100px; }
         .total-grade-container .label { font-size: 0.9em; color: #666; margin-bottom: 5px; }
         .total-grade-container .grade-value { font-size: 2em; font-weight: 700; color: var(--grade-text); }
@@ -618,6 +619,53 @@
             
                     </div>
                 </div>
+            <script>
+        const savedInputs = JSON.parse(localStorage.getItem('talentInputs') || '{}');
+        const savedFinals = JSON.parse(localStorage.getItem('speedGrades') || '{}');
+
+        document.querySelectorAll('.subject-card').forEach(card => {
+            const subject = card.querySelector('h4').innerText.trim();
+            const boxes = card.querySelectorAll('.static-box');
+            boxes.forEach((box, idx) => {
+                const input = document.createElement('input');
+                input.type = 'number';
+                input.min = 1;
+                input.max = 3;
+                input.className = 'grade-input';
+                if (savedInputs[subject] && savedInputs[subject][idx] !== undefined) {
+                    input.value = savedInputs[subject][idx];
+                }
+                box.replaceWith(input);
+                input.addEventListener('input', updateGrades);
+            });
+            if (savedFinals[subject]) {
+                card.querySelector('.grade-value').textContent = savedFinals[subject];
+            }
+        });
+
+        function updateGrades() {
+            const inputsData = {};
+            const finalGrades = {};
+            document.querySelectorAll('.subject-card').forEach(card => {
+                const subject = card.querySelector('h4').innerText.trim();
+                const inputs = card.querySelectorAll('.grade-input');
+                const values = Array.from(inputs).map(inp => parseFloat(inp.value));
+                inputsData[subject] = values;
+                if (values.every(v => !isNaN(v))) {
+                    const sum = values.reduce((s,v)=>s+v,0);
+                    const final = ((sum - 3) / 6) * 10;
+                    card.querySelector('.grade-value').textContent = final.toFixed(2);
+                    finalGrades[subject] = parseFloat(final.toFixed(2));
+                } else {
+                    card.querySelector('.grade-value').textContent = '-';
+                }
+            });
+            localStorage.setItem('talentInputs', JSON.stringify(inputsData));
+            localStorage.setItem('speedGrades', JSON.stringify(finalGrades));
+        }
+
+        updateGrades();
+        </script>
             </body>
             </html>
             


### PR DESCRIPTION
## Summary
- Add editable grade inputs in talent grader that calculate subject scores and store them in localStorage
- Initialize ranking.js speed grades from saved talent results so rankings reflect user input

## Testing
- `node --check ranking.js && echo "Syntax OK"`


------
https://chatgpt.com/codex/tasks/task_e_6891ca557f4c83209f219ae0d107ec31