### PR TITLE
Ensure talent grades update reliably

### DIFF
--- a/talentgrader.html
+++ b/talentgrader.html
@@ -574,7 +574,9 @@ function saveAll(savedInputs, speedGrades) {
 
     // Initialize each card: prefer storage; otherwise read from DOM; then compute & persist
     document.querySelectorAll('.subject-card').forEach(card => {
-      const subject = card.querySelector('h4')?.innerText.trim();
+      const subjectEl = card.querySelector('h4');
+      if (!subjectEl) return;
+      const subject = subjectEl.innerText.trim();
       const boxes = card.querySelectorAll('.static-box');
       const gradeEl = card.querySelector('.grade-value');
 
@@ -607,7 +609,9 @@ function saveAll(savedInputs, speedGrades) {
 
     // Live update on edit
     function recalcAndSave(card) {
-      const subject = card.querySelector('h4')?.innerText.trim();
+      const subjectEl = card.querySelector('h4');
+      if (!subjectEl) return;
+      const subject = subjectEl.innerText.trim();
       const boxes = card.querySelectorAll('.static-box');
       const gradeEl = card.querySelector('.grade-value');
 


### PR DESCRIPTION
## Summary
- Avoid optional chaining when extracting subject names so talent grades calculate in browsers without modern JS features

## Testing
- `node --check /tmp/script_temp.js && echo 'syntax ok'`


------
https://chatgpt.com/codex/tasks/task_e_689cddb397a0832080e588e5f02c3877