### PR TITLE
Clamp talent grades to valid range

### DIFF
--- a/talentgrader.html
+++ b/talentgrader.html
@@ -552,7 +552,9 @@ function toLatinDigitsAndSeparators(str) {
 function parseNum(text) {
   const t = toLatinDigitsAndSeparators(text).trim();
   const n = parseFloat(t);
-  return Number.isFinite(n) ? n : null;
+  if (!Number.isFinite(n)) return null;
+  // restrict values to the 1-3 range
+  return Math.max(1, Math.min(3, n));
 }
 
 function numbersValid(arr) {


### PR DESCRIPTION
## Summary
- Clamp parsed numbers between 1 and 3 in the talent grader to avoid inflated results

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689cdff146f883209b87f3acb2d963de